### PR TITLE
Added a pause for VDC execution

### DIFF
--- a/Community Scripts/get_disp_num.ps1
+++ b/Community Scripts/get_disp_num.ps1
@@ -1,1 +1,12 @@
-Get-Monitor | Where-Object { $_.InstanceName -like '*MTT1337*' } | Sort-Object { [int] (($_.InstanceName -match 'UID(\d+)') -and $Matches[1]) } | Select-Object -First 1 -ExpandProperty LogicalDisplay | select-object Devicename
+# One-liner to get the logicalname of the first VDD
+# You can alter the script -First 3, would make the third in the list, 
+# or -Last 2 would give second from last.
+
+$dispnum = (Get-Monitor | Where-Object { $_.InstanceName -like '*MTT1337*' } | Sort-Object { [int] (($_.InstanceName -match 'UID(\d+)') -and $Matches[1]) } | Select-Object -First 1).LogicalDisplay.DeviceName
+
+# Echo the result to console
+Write-Host $dispnum
+
+# Pause the console from closeing when executed from VDC
+Write-Host "Press any key to continue ..."
+$host.UI.RawUI.ReadKey("NoEcho,IncludeKeyDown") | Out-Null


### PR DESCRIPTION
Documented the script a bit, removed non essential header and added "Press any key..."-pause for VDC execution, .  Now you get a clear screen, example 8:
 \\.\DISPLAY8 
Press any key to continue ...

PR'd for approval ;)